### PR TITLE
Replace hero headline text with image

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -118,6 +118,18 @@ body {
   display: flex;
 }
 
+.mil-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  white-space: nowrap;
+}
+
 .mil-vert-between {
   display: -webkit-box;
   display: -ms-flexbox;
@@ -1799,6 +1811,16 @@ banner
   width: 100%;
   padding-bottom: 120px;
   position: relative;
+}
+.mil-banner-heading {
+  display: inline-block;
+  position: relative;
+}
+.mil-hero-heading {
+  display: block;
+  max-width: 640px;
+  width: 100%;
+  height: auto;
 }
 @media screen and (max-width: 992px) {
   .mil-banner .mil-banner-content {

--- a/home-1.html
+++ b/home-1.html
@@ -225,7 +225,10 @@
                         <div class="container">
                             <div class="mil-banner-content mil-up">
 
-                                <h1 class="mil-muted mil-mb-60">O Melhor <span class="mil-thin">para a sua</span><br> empresa <span class="mil-thin">está aqui</span></h1>
+                                <h1 class="mil-banner-heading mil-mb-60">
+                                    <span class="mil-visually-hidden">O Melhor para a sua empresa está aqui</span>
+                                    <img src="img/graphics/hero-heading.svg" class="mil-hero-heading" alt="" aria-hidden="true">
+                                </h1>
                                 <div class="row">
                                     <div class="col-md-7 col-lg-5">
 

--- a/img/graphics/hero-heading.svg
+++ b/img/graphics/hero-heading.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="940" height="220" viewBox="0 0 940 220" role="img" aria-labelledby="title desc">
+  <title id="title">Mensagem principal da Mbu Studio</title>
+  <desc id="desc">Texto promocional que diz: O Melhor para a sua empresa está aqui.</desc>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700&display=swap');
+    text {
+      font-family: 'Outfit', sans-serif;
+      fill: #ffffff;
+      letter-spacing: -0.5px;
+    }
+    .light {
+      fill: #9ca1ab;
+      font-weight: 300;
+    }
+    .bold {
+      font-weight: 700;
+    }
+    .medium {
+      font-weight: 500;
+    }
+  </style>
+  <rect width="940" height="220" fill="none" />
+  <text x="0" y="92" class="bold" font-size="86">O Melhor</text>
+  <text x="0" y="160" class="light" font-size="62">para a sua</text>
+  <text x="360" y="160" class="bold" font-size="62">empresa</text>
+  <text x="650" y="160" class="light" font-size="62">está aqui</text>
+</svg>


### PR DESCRIPTION
## Summary
- replace the landing hero heading text with an SVG image asset to match the desired layout
- add helper styles for the hero image and visually hidden text to preserve accessibility

## Testing
- python3 -m http.server 8000 (manual verification of home-1.html)


------
https://chatgpt.com/codex/tasks/task_e_68ee73b47794832aa22004a0d53f5573